### PR TITLE
Fix the client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 env/
 .tox/
 .python-version
+venv/

--- a/chargify/__init__.py
+++ b/chargify/__init__.py
@@ -1,3 +1,1 @@
-__version__ = '0.0.1'
-
 from .chargify import *

--- a/chargify/chargify.py
+++ b/chargify/chargify.py
@@ -1,20 +1,5 @@
 import requests
 
-
-__all__ = (
-    'ChargifyError',
-    'ChargifyConnectionError',
-    'ChargifyUnauthorizedError',
-    'ChargifyForbiddenError',
-    'ChargifyNotFoundError',
-    'ChargifyDuplicateSubmissionError',
-    'ChargifyUnprocessableEntityError',
-    'ChargifyServerError',
-    'ChargifyHttpClient',
-    'Chargify',
-)
-
-
 class ChargifyError(Exception):
     """
     Base Charfigy error exception.
@@ -110,7 +95,6 @@ class ChargifyHttpClient(object):
                                     auth=(api_key, 'X'))
 
         is_json = 'json' in response.headers.get('content-type')
-
         if response.ok:
             if is_json:
                 return response.json()
@@ -202,3 +186,29 @@ class Chargify(object):
         url, method, params, data = self.construct_request(**kwargs)
         return self.client.make_request(url, method, params, data,
                                         self.api_key)
+
+class ChargifyClient(object):
+    """
+    An actual pythonic and EXPLICIT client for the Chargify API.
+    """
+    api_key = ''
+    sub_domain = ''
+    domain = 'https://%s.chargify.com'
+    client = ChargifyHttpClient()
+
+    def __init__(self, api_key, sub_domain):
+        """
+        :param api_key: The API key for your Chargify account.
+        :param sub_domain: The sub domain of your Chargify account.
+        """
+        self.api_key = api_key
+        self.domain = self.domain % sub_domain
+
+    def get_management_link(self, customer_id):
+        """
+        endpoint: /portal/customers/{customer_id}/management_link.json
+        :param customer_id: get the Chargify Billing Portal Management Link for 
+        the given customer id. 
+        """
+        url = self.domain + f"/portal/customers/{customer_id}/management_link.json"
+        return self.client.make_request(url, "GET", None, None, self.api_key)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup(
     author='Ben Tappin',
     author_email='ben@codekitchen.io',
     packages=find_packages(exclude=['test_*.py']),
+    install_requires=[
+        'requests',
+    ]
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ from setuptools import setup, find_packages
 
 import chargify
 
+__version__ = '0.0.1'
+
 with open('README.md') as f:
     readme = f.read()
 
@@ -11,7 +13,7 @@ with open('LICENSE') as f:
 
 setup(
     name='chargify-python',
-    version=chargify.__version__,
+    version=__version__,
     long_description=readme,
     url='https://github.com/code-kitchen/chargify-python/',
     license=license,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(exclude=['test_*.py']),
     install_requires=[
         'requests',
-    ]
+    ],
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 from setuptools import setup, find_packages
 
-import chargify
-
 __version__ = '0.0.1'
 
 with open('README.md') as f:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='ben@codekitchen.io',
     packages=find_packages(exclude=['test_*.py']),
     install_requires=[
-        'requests',
+        'requests>=2.22.0',
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Issues:

1.  The setup.py imports the `requests` package but on the time of `pip install` in docker's build, jenkins, and etc the requests package is not installed yet and cannot be imported causing a failure to install. 
2. This library does not support the Billing Portal endpoints... To delve further into the overall issue of the library is that it does not use any explicit end points, instead is constructs very basic endpoints through enumerating through a list of defined keywords to then create the url to the endpoint. 

Solutions: 

1. Added the version number directly to the file so we don't have to import chargify into the setup file. This avoids the issue of chargify needing to detect the requests lib
2. Started working on a more pythonic and explicit client that will help make the calls in the future.